### PR TITLE
Fix for scrolling issue when FixedColumns is combined with Scroller plugin

### DIFF
--- a/media/js/FixedColumns.js
+++ b/media/js/FixedColumns.js
@@ -885,7 +885,7 @@ FixedColumns.prototype = {
 
 		if ( bAll )
 		{
-			if ( typeof this.s.dt.oScroller !== undefined )
+			if ( typeof this.s.dt.oScroller != 'undefined' )
 			{
 				oGrid.body.appendChild( this.s.dt.oScroller.dom.force.cloneNode(true) );
 			}


### PR DESCRIPTION
There could well be a better location/way to do this ...

First if is testing for bAll so that it happens only once ... 
second if is testing if Scroller plugin exists ... 
then just clone Scroller's div that is the full height of the table
