### PR TITLE
Update dataTables.fixedColumns.js

### DIFF
--- a/media/js/dataTables.fixedColumns.js
+++ b/media/js/dataTables.fixedColumns.js
@@ -46,7 +46,7 @@ var FixedColumns;
  *
  *  @example
  *      var table = $('#example').dataTable( {
- *        "scrollX": "100%"
+ *        "sScrollX": "100%"
  *      } );
  *      new $.fn.dataTable.fixedColumns( table );
  */


### PR DESCRIPTION
There's a mistake in the documentation/comments on line 49 - it says "scrollX" and it should say "sScrollX".
