### PR TITLE
Change sanity check to actually check sanely

### DIFF
--- a/js/dataTables.fixedColumns.js
+++ b/js/dataTables.fixedColumns.js
@@ -62,7 +62,7 @@ var FixedColumns = function ( dt, init ) {
 	var that = this;
 
 	/* Sanity check - you just know it will happen */
-	if ( ! this instanceof FixedColumns )
+	if ( ! ( this instanceof FixedColumns ) )
 	{
 		alert( "FixedColumns warning: FixedColumns must be initialised with the 'new' keyword." );
 		return;


### PR DESCRIPTION
As the comment implies, it was bound to happen to someone, and I guess I was the lucky fool who couldn't read...but without the parentheses operator associativity has the sanity check ensuring `false instanceof FixedColumns`, and that just leads to an unhelpful error trying to [invoke `_fnConstruct` later on](https://github.com/DataTables/FixedColumns/blob/095c43bf6662d9a48aa6fe886527beb759f87fb7/js/dataTables.fixedColumns.js#L275).

Adding in the missing parentheses makes sure the developer gets the appropriate message when they forget `new`.
