### PR TITLE
Account for IE under-reporting scroll bar size

### DIFF
--- a/js/dataTables.fixedColumns.js
+++ b/js/dataTables.fixedColumns.js
@@ -786,7 +786,7 @@ $.extend( FixedColumns.prototype , {
 			}
 			else {
 				// Otherwise just overflow by the scrollbar
-				node.style.width = (width+oOverflow.bar)+"px";
+				node.style.width = (width+oOverflow.bar+1)+"px";
 			}
 		};
 


### PR DESCRIPTION
On (at least) IE11 under Windows 7, the scroll bar size returned is 1 pixel smaller than it should be. This can cause two scrollbars to end up being shown stacked on top of each other in the grid.

The circumstances that two scrollbars can end up being shown are when there are multiple columns with long names, along with rows that also have long names. (e.g.: 20 columns of "jfdsklfjdsklfjlkfdlskfjdlskfjdlskfjlkdsfkldksdljdlksfjdlskfjdslkfjdl" or similar, and rows with a similar character length) I was able to fix this in the local code I have by adding 1 to the width.