### PR TITLE
Fixed a thrown error on destroy()

### DIFF
--- a/js/dataTables.fixedColumns.js
+++ b/js/dataTables.fixedColumns.js
@@ -620,7 +620,7 @@ $.extend( FixedColumns.prototype , {
 
 				$(that.dom.scroller).off( '.DTFC' );
 				$(window).off( '.DTFC' );
-				$(this.s.dt.nTableWrapper).off( '.DTFC' );
+				$(that.s.dt.nTableWrapper).off( '.DTFC' );
 
 				$(that.dom.grid.left.liner).off( '.DTFC '+wheelType );
 				$(that.dom.grid.left.wrapper).remove();


### PR DESCRIPTION
Solves a thrown error:

Uncaught TypeError: Cannot read property 'dt' of undefined 
at dataTables.fixedColumns.js:621
