### PR TITLE
Fix transparent background on odd rows

### DIFF
--- a/css/fixedColumns.bootstrap.scss
+++ b/css/fixedColumns.bootstrap.scss
@@ -1,5 +1,4 @@
-
-table.DTFC_Cloned tr.even {
+table.DTFC_Cloned tr {
 	background-color: white;
 	margin-bottom: 0;
 }


### PR DESCRIPTION
If you look at https://github.com/DataTables/FixedColumns/blob/master/css/fixedColumns.bootstrap.scss#L2-L5

``` css
table.DTFC_Cloned tr.even {
    background-color: white;
    margin-bottom: 0;
}
```

Only even rows have the white background-color... resulting in odd rows with transparent backgrounds, thus we see what scrolls behind the first column.