### PR TITLE
Fixed indexing issue 

### DIFF
--- a/js/dataTables.fixedColumns.js
+++ b/js/dataTables.fixedColumns.js
@@ -1217,7 +1217,7 @@ $.extend( FixedColumns.prototype , {
 					{
 						nClone = $( aTds[iColumn] ).clone(true, true)[0];
 						nClone.setAttribute( 'data-dt-row', i );
-						nClone.setAttribute( 'data-dt-column', iIndex );
+						nClone.setAttribute( 'data-dt-column', iColumn );
 						n.appendChild( nClone );
 					}
 				}


### PR DESCRIPTION
I had an  issue when using the keytable plugin to navigate and use it to select rows in datatables. This plugin outputted the wrong column indexes when there was 1 or more columns hidden in front of a fixed column. This seems to have fixed the problem.