### PR TITLE
fix scroll bar if hide for first fixed column

### DIFF
--- a/js/dataTables.fixedColumns.js
+++ b/js/dataTables.fixedColumns.js
@@ -674,10 +674,22 @@ $.extend( FixedColumns.prototype , {
 				// Outer width is used to calculate the container
 				var iWidth = th.outerWidth();
 
+				// resole scroll bar if it hide the first column
+                // check if the previous column is all hidden or not
+                // if true it need to add additional border to avoid width scrollbar
+                var previousAllHidden = true;
+                var arrayLength = that.s.aiOuterWidths.length;
+                for (var j = 0; i < arrayLength; i++) {
+                    if(that.s.aiOuterWidths[j] != 0){
+                        previousAllHidden = false;
+                        break;
+                    }
+                }
+
 				// When working with the left most-cell, need to add on the
 				// table's border to the outerWidth, since we need to take
 				// account of it, but it isn't in any cell
-				if ( that.s.aiOuterWidths.length === 0 ) {
+				if ( that.s.aiOuterWidths.length === 0 || previousAllHidden) {
 					border = $(that.s.dt.nTable).css('border-left-width');
 					iWidth += typeof border === 'string' && border.indexOf('px') === -1 ?
 						1 :


### PR DESCRIPTION
FixedColumn is a powerful plugin to create nice grids. It greatly helps
to my work. Recent I found one issue when using fixed column:

If it hide the first left column(which is also included as fixed
column), there would be a x-scrollbar displayed for the left side.
Tested on my mac with mouse connected. If I use touch pad, it works
fine.

This is because border(usually 1px) missing in the calculation.
This is my first pull request. Please review.

![snip20171219_1](https://user-images.githubusercontent.com/10395563/34150657-fbbe253c-e4e3-11e7-88d3-295451aeff85.png)
