### PR TITLE
Fixed TypeError: that.s.dt.aoData[i] is undefined

### DIFF
--- a/js/dataTables.fixedColumns.js
+++ b/js/dataTables.fixedColumns.js
@@ -1229,7 +1229,7 @@ $.extend( FixedColumns.prototype , {
 			/* Add in the tbody elements, cloning form the master table */
 			$('>tbody>tr', that.dom.body).each( function (z) {
 				var i = that.s.dt.oFeatures.bServerSide===false ?
-					that.s.dt.aiDisplay[ that.s.dt._iDisplayStart+z ] : z;
+					that.s.dt.aiDisplay[ parseInt(that.s.dt._iDisplayStart, 10) + z ] : z;
 				var aTds = that.s.dt.aoData[ i ].anCells || $(this).children('td, th');
 
 				var n = this.cloneNode(false);


### PR DESCRIPTION
When the server side rendering is disabled (bServerSide===false) the part causes an JS error, cause:
* that.s.dt._iDisplayStart is of type string
* z is of type number 
So the result for i was "00" and the following code line crashed with that.s.dt.aoData[00], cause this key does not exist in the array